### PR TITLE
Updated for the latest Adafruit_ZeroTimer library (version 2.0).

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,70 @@
 # Avdweb_SAMDtimer
-SAMD21 Timer library for the SAM15x15 and Arduino Zero
-http://www.avdweb.nl/arduino/libraries/samd21-timer.html
+
+SAMD21 Timer library for the SAM15x15 and Arduino Zero compatible boards.
 
 This library needs the [Adafruit_ZeroTimer](https://github.com/adafruit/Adafruit_ZeroTimer/) library to run.
+
+For more information visit http://www.avdweb.nl/arduino/libraries/samd21-timer.html
+
+##Basic usage
+
+###1. Using a timer with an output pin
+
+The library is easy to use; the following code generates a square wave of 1Hz to pin 5 of the Arduino Zero:
+
+    SAMDtimer mytimer1 = SAMDtimer(3, TC_COUNTER_SIZE_16BIT, 5, 1e6,true);
+
+**Explanation:**
+
+- `Mytimer1`: this is the object name of you choice.
+- `3`: the pin-table shows that timer3 should be used for output pin 5.
+- `TC_COUNTER_SIZE_16BIT`: don't change. This parameter exists just to make the library expandable.
+- `5`: output pin 5
+- `1e6`: we need to specify the period time in microseconds.
+- `true`: optional parameter, specifie if the timer should be enabled (started) or not.
+
+Alert readers might notice that the first two parameters are not strictly necessary because these could be derived from the used pin and period time. However, this would make the timer library less expandable and there will be occur more mistakes with the pin assignments, if more timers are used.
+
+**Notes**
+
+- The maximum period time is 1398080us (0.7Hz).
+- The minimum period time is = 2us (500kHz).
+- For now, the library has three timers available (number 3, 4, 5), only in 16-bit mode.
+- There is no check on the proper parameters values.
+- Without specifying the pulse width, it is the half of the period time (duty cycle 50%).
+
+### 2 Timer interrupts
+
+A timer can also be used for calling interrupts, without using a timer output pin. To periodically execute an ISR, simply use this code:
+
+    SAMDtimer mytimer2 = SAMDtimer(4, myISR, 5e5, true);
+
+**Explanation:**
+
+- `Mytimer2`: this is the object name of you choice.
+- `4`: take any free timer
+- `myISR`: the name of the ISR of you choice.
+- `5e5`: the period time in microseconds.
+- `true`: optional parameter, specifie if the timer should be enabled (started) or not.
+
+The ISR should look as follows:
+
+    void myISR ()
+    {
+        //your code here
+    }
+
+## 3 Attaching interrupts to a timer with an output pin
+
+A timer can be used for both calling an interrupt and steering its output pin at the same time. This has to be carried out in two steps: first create a timer with an output pin, and than attach an ISR to it.
+
+    Mytimer3.attachInterrupt(myISR);
+
+**Explanation:**
+
+- `Mytimer3`: an existing timer with an output pin, see paragraph 1.
+- `myISR`: the name of the ISR, see paragraph 2.
+
+**Notes**
+
+- If the timer is disabled, then the ISR is disabled also.

--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ This library needs the [Adafruit_ZeroTimer](https://github.com/adafruit/Adafruit
 
 For more information visit http://www.avdweb.nl/arduino/libraries/samd21-timer.html
 
-##Basic usage
+## Basic usage
 
-###1. Using a timer with an output pin
+### 1. Using a timer with an output pin
 
 The library is easy to use; the following code generates a square wave of 1Hz to pin 5 of the Arduino Zero:
 
@@ -33,7 +33,7 @@ Alert readers might notice that the first two parameters are not strictly necess
 - There is no check on the proper parameters values.
 - Without specifying the pulse width, it is the half of the period time (duty cycle 50%).
 
-### 2 Timer interrupts
+### 2. Timer interrupts
 
 A timer can also be used for calling interrupts, without using a timer output pin. To periodically execute an ISR, simply use this code:
 
@@ -54,7 +54,7 @@ The ISR should look as follows:
         //your code here
     }
 
-## 3 Attaching interrupts to a timer with an output pin
+### 3. Attaching interrupts to a timer with an output pin
 
 A timer can be used for both calling an interrupt and steering its output pin at the same time. This has to be carried out in two steps: first create a timer with an output pin, and than attach an ISR to it.
 

--- a/README.md
+++ b/README.md
@@ -2,5 +2,4 @@
 SAMD21 Timer library for the SAM15x15 and Arduino Zero
 http://www.avdweb.nl/arduino/libraries/samd21-timer.html
 
-Attention: The new libraries Adafruit_ASFcore and Adafruit_ZeroTimer don't work anymore with the avdweb_SAMDtimer library.
-Therefore, install the older libraries, see the zip files.
+This library needs the [Adafruit_ZeroTimer](https://github.com/adafruit/Adafruit_ZeroTimer/) library to run.

--- a/avdweb_SAMDtimer.cpp
+++ b/avdweb_SAMDtimer.cpp
@@ -35,7 +35,7 @@ Adafruit_ZeroTimer(timerNr), pin(pin), countersize(countersize), period_us(perio
   init(timerEnable);    
 }
 
-SAMDtimer::SAMDtimer(byte timerNr, tc_callback_t _ISR, unsigned period_us, bool ISRenable):
+SAMDtimer::SAMDtimer(byte timerNr, void (*_ISR)(), unsigned period_us, bool ISRenable):
 Adafruit_ZeroTimer(timerNr)  
 { ISR = _ISR;
   countersize = TC_COUNTER_SIZE_16BIT; 
@@ -49,7 +49,7 @@ void SAMDtimer::setPulseWidth(unsigned pulseWidth_us)
   setPeriodMatch(periodCounter, PWcounter, 1); 
 }
 
-void SAMDtimer::attachInterrupt(tc_callback_t _ISR, bool interruptEnable)
+void SAMDtimer::attachInterrupt(void (*_ISR)(), bool interruptEnable)
 { ISR = _ISR;
   setCallback(interruptEnable, TC_CALLBACK_CC_CHANNEL1, ISR); 
 }

--- a/avdweb_SAMDtimer.cpp
+++ b/avdweb_SAMDtimer.cpp
@@ -50,16 +50,10 @@ Adafruit_ZeroTimer(timerNr), pin(pin), countersize(countersize), period_us(perio
 SAMDtimer::SAMDtimer(byte timerNr, void (*_ISR)(), unsigned period_us, bool ISRenable):
 Adafruit_ZeroTimer(timerNr)  
 { ISR = _ISR;
-  //countersize = TC_COUNTER_SIZE_16BIT; 
-  //calc(period_us, period_us/2);
-  //init(1);
-  configure(TC_CLOCK_PRESCALER_DIV1024, // prescaler
-      TC_COUNTER_SIZE_16BIT,   // bit width of timer/counter
-      TC_WAVE_GENERATION_MATCH_PWM // frequency or PWM mode
-  );
-  setPeriodMatch(46854, 23427,1);
+  countersize = TC_COUNTER_SIZE_16BIT; 
+  calc(period_us, period_us/2);
+  init(1);
   setCallback(ISRenable, TC_CALLBACK_CC_CHANNEL0, ISR);
-  enable(ISRenable);
 }
 
 void SAMDtimer::setPulseWidth(unsigned pulseWidth_us)

--- a/avdweb_SAMDtimer.cpp
+++ b/avdweb_SAMDtimer.cpp
@@ -50,6 +50,7 @@ Adafruit_ZeroTimer(timerNr), pin(pin), countersize(countersize), period_us(perio
 SAMDtimer::SAMDtimer(byte timerNr, void (*_ISR)(), unsigned period_us, bool ISRenable):
 Adafruit_ZeroTimer(timerNr)  
 { ISR = _ISR;
+  pin=-1;
   countersize = TC_COUNTER_SIZE_16BIT; 
   calc(period_us, period_us/2);
   init(1);
@@ -76,7 +77,7 @@ void SAMDtimer::enableInterrupt(bool interruptEnable)
 
 void SAMDtimer::init(bool enabled)
 { configure(prescale, countersize, TC_WAVE_GENERATION_MATCH_PWM);
-  //PWMout(true, 1, pin); // must be ch1 for 16bit
+  if(pin>0)PWMout(true, 1, pin); // must be ch1 for 16bit
   setPeriodMatch(periodCounter, PWcounter, 1);
   enable(enabled); 
 }
@@ -93,8 +94,3 @@ void SAMDtimer::calc(unsigned period_us, unsigned pulseWidth_us)
   else if((PWcounter >>= 2, periodCounter >>= 2) < 65536) prescale = TC_CLOCK_PRESCALER_DIV256; 
   else if((PWcounter >>= 2, periodCounter >>= 2) < 65536) prescale = TC_CLOCK_PRESCALER_DIV1024; 
 }
-
-
-
-
-

--- a/avdweb_SAMDtimer.cpp
+++ b/avdweb_SAMDtimer.cpp
@@ -28,6 +28,18 @@ SAMDtimer 5 16bit  D24/SCK*1                      d[13]
 
 #include "avdweb_SAMDtimer.h"
 
+void TC3_Handler(){
+    Adafruit_ZeroTimer::timerHandler(3);
+}
+
+void TC4_Handler(){
+    Adafruit_ZeroTimer::timerHandler(4);
+}
+
+void TC5_Handler(){
+    Adafruit_ZeroTimer::timerHandler(5);
+}
+
 SAMDtimer::SAMDtimer(byte timerNr, tc_counter_size countersize, byte pin, unsigned period_us, int pulseWidth_us, bool timerEnable): 
 Adafruit_ZeroTimer(timerNr), pin(pin), countersize(countersize), period_us(period_us)  
 { if(pulseWidth_us==-1) calc(period_us, period_us/2);
@@ -38,10 +50,16 @@ Adafruit_ZeroTimer(timerNr), pin(pin), countersize(countersize), period_us(perio
 SAMDtimer::SAMDtimer(byte timerNr, void (*_ISR)(), unsigned period_us, bool ISRenable):
 Adafruit_ZeroTimer(timerNr)  
 { ISR = _ISR;
-  countersize = TC_COUNTER_SIZE_16BIT; 
-  calc(period_us, period_us/2);
-  init(1);
-  setCallback(ISRenable, TC_CALLBACK_CC_CHANNEL1, ISR); 
+  //countersize = TC_COUNTER_SIZE_16BIT; 
+  //calc(period_us, period_us/2);
+  //init(1);
+  configure(TC_CLOCK_PRESCALER_DIV1024, // prescaler
+      TC_COUNTER_SIZE_16BIT,   // bit width of timer/counter
+      TC_WAVE_GENERATION_MATCH_PWM // frequency or PWM mode
+  );
+  setPeriodMatch(46854, 23427,1);
+  setCallback(ISRenable, TC_CALLBACK_CC_CHANNEL0, ISR);
+  enable(ISRenable);
 }
 
 void SAMDtimer::setPulseWidth(unsigned pulseWidth_us)
@@ -51,7 +69,7 @@ void SAMDtimer::setPulseWidth(unsigned pulseWidth_us)
 
 void SAMDtimer::attachInterrupt(void (*_ISR)(), bool interruptEnable)
 { ISR = _ISR;
-  setCallback(interruptEnable, TC_CALLBACK_CC_CHANNEL1, ISR); 
+  setCallback(interruptEnable, TC_CALLBACK_CC_CHANNEL0, ISR); 
 }
 
 void SAMDtimer::enableTimer(bool timerEnable)
@@ -59,12 +77,12 @@ void SAMDtimer::enableTimer(bool timerEnable)
 }
 
 void SAMDtimer::enableInterrupt(bool interruptEnable)
-{ setCallback(interruptEnable, TC_CALLBACK_CC_CHANNEL1, ISR); 
+{ setCallback(interruptEnable, TC_CALLBACK_CC_CHANNEL0, ISR); 
 }
 
 void SAMDtimer::init(bool enabled)
 { configure(prescale, countersize, TC_WAVE_GENERATION_MATCH_PWM);
-  PWMout(true, 1, pin); // must be ch1 for 16bit
+  //PWMout(true, 1, pin); // must be ch1 for 16bit
   setPeriodMatch(periodCounter, PWcounter, 1);
   enable(enabled); 
 }

--- a/avdweb_SAMDtimer.h
+++ b/avdweb_SAMDtimer.h
@@ -14,9 +14,9 @@ of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Publ
 class SAMDtimer : public Adafruit_ZeroTimer 
 { public:
     SAMDtimer(byte timerNr, tc_counter_size countersize, byte pin, unsigned period_us, int pulseWidth_us=-1, bool timerEnable=1); // For timer with output
-    SAMDtimer(byte timerNr, tc_callback_t _ISR, unsigned period_us, bool ISRenable=1); // For timer interrupt, without output 
+    SAMDtimer(byte timerNr, void (*_ISR)(), unsigned period_us, bool ISRenable=1); // For timer interrupt, without output 
     
-    void attachInterrupt(tc_callback_t _ISR, bool interruptEnable=1); // attach ISR to a timer with output, or exchange the ISR
+    void attachInterrupt(void (*_ISR)(), bool interruptEnable=1); // attach ISR to a timer with output, or exchange the ISR
     void enableTimer(bool timerEnable);
     void enableInterrupt(bool interruptEnable);
     void setPulseWidth(unsigned pulseWidth_us);
@@ -26,7 +26,7 @@ class SAMDtimer : public Adafruit_ZeroTimer
     void calc(unsigned period_us, unsigned pulseWidth_us);  
 
     byte pin;
-    tc_callback_t ISR;
+    void (*ISR)();
     unsigned period_us, periodCounter, PWcounter;
     tc_clock_prescaler prescale;
     tc_counter_size countersize;  

--- a/examples/SAMDtimer_examples/SAMDtimer_examples.ino
+++ b/examples/SAMDtimer_examples/SAMDtimer_examples.ino
@@ -8,19 +8,19 @@ const byte LED2   = 0;
 const byte LED3   = 2;
 const byte LED4   = 5; // timer3 16bit has 2 pins: 5 12
 
-void ISR_timer3_LED1(struct tc_module *const module_inst) 
+void ISR_timer3_LED1()
 { static bool b;
   pinMode(LED1, OUTPUT);
   digitalWrite(LED1, b=!b);
 }
 
-void ISR_timer4_LED2(struct tc_module *const module_inst) 
+void ISR_timer4_LED2()
 { static bool b;
   pinMode(LED2, OUTPUT);
   digitalWrite(LED2, b=!b);
 }
 
-void ISR_timer4_LED3(struct tc_module *const module_inst) 
+void ISR_timer4_LED3()
 { static bool b;
   pinMode(LED3, OUTPUT);
   digitalWrite(LED3, b=!b);


### PR DESCRIPTION
Now it can be used with the official release, no need to install the outdated version from the avdweb website.

**NOTE** The interrupt handling functions don't need bizarre parameters anymore. Please update the documentation accordingly.

So

   void ISR_function(struct tc_module *const module_inst)

becomes simply:

   void ISR_function()